### PR TITLE
HLSProvider duration getter returns positive Infinity

### DIFF
--- a/src/com/videojs/providers/HLSProvider.as
+++ b/src/com/videojs/providers/HLSProvider.as
@@ -227,7 +227,7 @@ package com.videojs.providers{
           if(_hls.type == HLSTypes.VOD) {
             return _duration;
           } else {
-            return -1;
+            return Number.POSITIVE_INFINITY;
           }
         }
 


### PR DESCRIPTION
Hello,

would it be possible to make HLSProvider duration getter to return positive Infinity (instead of -1) for LIVE stream as stated in HTML standard for Video element? https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-duration

If not, could someone just tell me for what reason?

Thanks.

Vit